### PR TITLE
test: validate all WGSL shaders

### DIFF
--- a/tests/wgsl.rs
+++ b/tests/wgsl.rs
@@ -1,17 +1,26 @@
-//! Ensure that the WGSL shader parses and validates on the CPU.
+//! Ensure that every WGSL shader parses and validates on the CPU.
+
+use std::fs;
 
 #[test]
-fn seq_wgsl_compiles() {
-    let src = include_str!("../shaders/seq.wgsl");
+fn wgsl_files_compile() {
+    for entry in fs::read_dir("shaders").expect("read shaders dir") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|s| s.to_str()) != Some("wgsl") {
+            continue;
+        }
 
-    // Parse WGSL source using Naga (CPU implementation of WGSL frontend)
-    let module = naga::front::wgsl::parse_str(src).expect("WGSL parse");
+        let src = fs::read_to_string(&path).expect("read WGSL file");
 
-    // Validate the module – catches type or binding errors without requiring a GPU device
-    let mut validator = naga::valid::Validator::new(
-        naga::valid::ValidationFlags::all(),
-        naga::valid::Capabilities::all(),
-    );
+        // Parse WGSL source using Naga (CPU implementation of WGSL frontend)
+        let module = naga::front::wgsl::parse_str(&src).expect("WGSL parse");
 
-    validator.validate(&module).expect("WGSL validation");
+        // Validate the module – catches type or binding errors without requiring a GPU device
+        let mut validator = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::all(),
+        );
+
+        validator.validate(&module).expect("WGSL validation");
+    }
 }


### PR DESCRIPTION
## Summary
- ensure WGSL validation runs for every shader in `shaders/`

## Testing
- `cargo +nightly fmt --all`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly test -j 1 -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68a598ec3f6c833396a9b06fbd73d11e