### PR TITLE
ci: add formatting, clippy, and tests workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
     - uses: actions/checkout@v4
@@ -20,6 +20,6 @@ jobs:
     - name: Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
     - name: Tests
-      run: cargo test -j 1 -- --test-threads=1
+      run: cargo test --verbose -j 1 -- --test-threads=1
     - name: Build
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,15 @@ env:
 
 jobs:
   build:
-
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+    - name: Format check
+      run: cargo fmt --all -- --check
+    - name: Clippy
+      run: cargo clippy --all-targets --all-features -- -D warnings
+    - name: Tests
+      run: cargo test -j 1 -- --test-threads=1
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose


### PR DESCRIPTION
## Summary
- run CI on standard ubuntu runner
- add formatting, lint, and test steps prior to build

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -j 1 -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68a5a9ac8b0c833384be05c1bac3285f